### PR TITLE
Replace empty github.com/controlthingstools link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Control Things Serial
+# Control Things Library UI
 
 The `ctui` is a library for creating terminal-based user interfaces, and is used in all the ControlThings tools at controlthings.io.  It is similar to using Click or Python's standard Cmd library, but with a curses-like interface written in pure Python.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ myapp = Ctui()
 myapp.run()
 ```
 
-Of course you can configure you app in a number of different ways by modifying your app's attributes or by adding your own custom commands.   Check out the `examples` folder to walk you through some of these.  For more complex examples how to use ctui, check out the various ControlThings Tools, most of which use ctui.  You can find these at https://github.com/ControlThingsTools.
+Of course you can configure you app in a number of different ways by modifying your app's attributes or by adding your own custom commands.   Check out the `examples` folder to walk you through some of these.  For more complex examples how to use ctui, check out the various ControlThings Tools, most of which use ctui.  You can find these at <https://www.controlthings.io/tools>.
 
 # Developing
 


### PR DESCRIPTION
Replace empty github.com/controlthingstools link with a page that shows the tools.